### PR TITLE
Fixed Verification URL in the Verification Email

### DIFF
--- a/demo/server.js
+++ b/demo/server.js
@@ -95,9 +95,10 @@ app.post('/ajax_handler/login', function (req, res) {
       var verificationUrl = 'http://localhost:3000/demo';
       var welcomeEmailTemplate = '';
       var fields = '';
+      var options = '';
 
       lrv2.helper.getSott(config).then(function (sott) {
-        lrv2.authenticationApi.userRegistrationByEmail(userprofileModel, sott, emailTemplate, fields, verificationUrl, welcomeEmailTemplate).then(function (response) {
+        lrv2.authenticationApi.userRegistrationByEmail(userprofileModel, sott, emailTemplate, fields, options, verificationUrl, welcomeEmailTemplate).then(function (response) {
           if ((response.EmailVerified)) {
             output.data = response;
             output.message = 'You have successfully registered.';


### PR DESCRIPTION
In the Verification email, the domain is missing because ` lrv2.authenticationApi.userRegistrationByEmail` needs 7 args but previously it was only 6 hence the previous email looks something like this

```
Hello ,

To verify your email, please click on following link and if your browser does not open it, please copy and paste it in your browser’s address bar.

?vtype=emailverification&vtoken=9afff6df702e43929c0839701f7f64ab

Regards
```

While Fixed one is
```
Hello ,

To verify your email, please click on following link and if your browser does not open it, please copy and paste it in your browser’s address bar.

http://localhost:3000/demo?vtype=emailverification&vtoken=a1243410be794657ba9f5957933eefee

Regards
```