### PR TITLE
Code cleanings: Template literals and padStart

### DIFF
--- a/demo/demo/assets/js/index.js
+++ b/demo/demo/assets/js/index.js
@@ -161,7 +161,7 @@ function handleMFALogin() {
                     var qrHtml = '';
                     var qrCode = res.data.SecondFactorAuthentication.QRCode;
                     if (!res.data.SecondFactorAuthentication.IsGoogleAuthenticatorVerified) {
-                        qrHtml = '<img src=' + qrCode + '><br/>';
+                        qrHtml = `<img src=${qrCode}><br/>`;
                     } else {
                         qrHtml = '';
                     }

--- a/demo/demo/assets/js/profile.js
+++ b/demo/demo/assets/js/profile.js
@@ -173,7 +173,7 @@ function getCustomObjects() {
                     for (var i = 0; i < res.result.data.length; i++) {
                         var id = res.result.data[i].Id;
                         var custobj = res.result.data[i].CustomObject;
-                        $('#customobj-table').append('<tr><td>' + id + '</td><td>' + JSON.stringify(custobj) + '</td></tr>');
+                        $('#customobj-table').append(`<tr><td>${id}</td><td>${JSON.stringify(custobj)}</td></tr>`);
                     }
                 }
             },
@@ -443,7 +443,7 @@ function getAllRoles() {
                     return;
                 for (var i = 0; i < res.result.data.length; i++) {
                     var name = res.result.data[i].Name;
-                    $('#table-allroles').append('<tr><td>' + name + '</td></tr>');
+                    $('#table-allroles').append(`<tr><td>${name}</td></tr>`);
                 }
             } else if (res.status == 'rolesempty') {
                 $('#table-allroles').html('');
@@ -475,7 +475,7 @@ function getUserRoles() {
                     return;
                 for (var i = 0; i < res.data.Roles.length; i++) {
                     var name = res.data.Roles[i];
-                    $('#table-userroles').append('<tr><td>' + name + '</td></tr>');
+                    $('#table-userroles').append(`<tr><td>${name}</td></tr>`);
                 }
             } else if (res.status == 'userrolesempty') {
                 $('#table-userroles').html('');

--- a/demo/server.js
+++ b/demo/server.js
@@ -571,4 +571,4 @@ app.post('/ajax_handler/profile', function (req, res) {
     });
   }
 });
-app.listen(PORT, () => console.log('Demo app can be accessed at localhost:' + PORT + '/demo'));
+app.listen(PORT, () => console.log(`Demo app can be accessed at localhost:${PORT}/demo`));

--- a/loginradius-sdk/sdk/api/account/accountApi.js
+++ b/loginradius-sdk/sdk/api/account/accountApi.js
@@ -22,7 +22,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/privacypolicy/history';
+    var resourcePath = `identity/v2/manage/account/${uid}/privacypolicy/history`;
 
     return config.request('GET', resourcePath, queryParameters, null);
   };
@@ -217,7 +217,7 @@ module.exports = function (config) {
     var bodyParameters = {};
     bodyParameters.phone = phone;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/phoneid';
+    var resourcePath = `identity/v2/manage/account/${uid}/phoneid`;
 
     return config.request('PUT', resourcePath, queryParameters, bodyParameters);
   };
@@ -238,7 +238,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/password';
+    var resourcePath = `identity/v2/manage/account/${uid}/password`;
 
     return config.request('GET', resourcePath, queryParameters, null);
   };
@@ -266,7 +266,7 @@ module.exports = function (config) {
     var bodyParameters = {};
     bodyParameters.password = password;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/password';
+    var resourcePath = `identity/v2/manage/account/${uid}/password`;
 
     return config.request('PUT', resourcePath, queryParameters, bodyParameters);
   };
@@ -317,7 +317,7 @@ module.exports = function (config) {
       queryParameters.verificationUrl = verificationUrl;
     }
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/invalidateemail';
+    var resourcePath = `identity/v2/manage/account/${uid}/invalidateemail`;
 
     return config.request('PUT', resourcePath, queryParameters, null);
   };
@@ -425,7 +425,7 @@ module.exports = function (config) {
       queryParameters.smsTemplate = smsTemplate;
     }
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/invalidatephone';
+    var resourcePath = `identity/v2/manage/account/${uid}/invalidatephone`;
 
     return config.request('PUT', resourcePath, queryParameters, null);
   };
@@ -455,7 +455,7 @@ module.exports = function (config) {
       queryParameters.fields = fields;
     }
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/email';
+    var resourcePath = `identity/v2/manage/account/${uid}/email`;
 
     return config.request('PUT', resourcePath, queryParameters, upsertEmailModel);
   };
@@ -488,7 +488,7 @@ module.exports = function (config) {
     var bodyParameters = {};
     bodyParameters.email = email;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/email';
+    var resourcePath = `identity/v2/manage/account/${uid}/email`;
 
     return config.request('DELETE', resourcePath, queryParameters, bodyParameters);
   };

--- a/loginradius-sdk/sdk/api/account/accountApi.js
+++ b/loginradius-sdk/sdk/api/account/accountApi.js
@@ -150,7 +150,7 @@ module.exports = function (config) {
       queryParameters.fields = fields;
     }
 
-    var resourcePath = 'identity/v2/manage/account/' + uid;
+    var resourcePath = `identity/v2/manage/account/${uid}`;
 
     return config.request('GET', resourcePath, queryParameters, null);
   };
@@ -184,7 +184,7 @@ module.exports = function (config) {
       queryParameters.nullSupport = nullSupport;
     }
 
-    var resourcePath = 'identity/v2/manage/account/' + uid;
+    var resourcePath = `identity/v2/manage/account/${uid}`;
 
     return config.request('PUT', resourcePath, queryParameters, accountUserProfileUpdateModel);
   };
@@ -287,7 +287,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid;
+    var resourcePath = `identity/v2/manage/account/${uid}`;
 
     return config.request('DELETE', resourcePath, queryParameters, null);
   };

--- a/loginradius-sdk/sdk/api/account/roleApi.js
+++ b/loginradius-sdk/sdk/api/account/roleApi.js
@@ -114,7 +114,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/rolecontext/' + contextName;
+    var resourcePath = `identity/v2/manage/account/rolecontext/${contextName}`;
 
     return config.request('GET', resourcePath, queryParameters, null);
   };
@@ -283,7 +283,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/role/' + role;
+    var resourcePath = `identity/v2/manage/role/${role}`;
 
     return config.request('DELETE', resourcePath, queryParameters, null);
   };

--- a/loginradius-sdk/sdk/api/account/roleApi.js
+++ b/loginradius-sdk/sdk/api/account/roleApi.js
@@ -22,7 +22,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/role';
+    var resourcePath = `identity/v2/manage/account/${uid}/role`;
 
     return config.request('GET', resourcePath, queryParameters, null);
   };
@@ -47,7 +47,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/role';
+    var resourcePath = `identity/v2/manage/account/${uid}/role`;
 
     return config.request('PUT', resourcePath, queryParameters, accountRolesModel);
   };
@@ -72,7 +72,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/role';
+    var resourcePath = `identity/v2/manage/account/${uid}/role`;
 
     return config.request('DELETE', resourcePath, queryParameters, accountRolesModel);
   };
@@ -93,7 +93,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/rolecontext';
+    var resourcePath = `identity/v2/manage/account/${uid}/rolecontext`;
 
     return config.request('GET', resourcePath, queryParameters, null);
   };
@@ -139,7 +139,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/rolecontext';
+    var resourcePath = `identity/v2/manage/account/${uid}/rolecontext`;
 
     return config.request('PUT', resourcePath, queryParameters, accountRoleContextModel);
   };
@@ -164,7 +164,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/rolecontext/' + contextName;
+    var resourcePath = `identity/v2/manage/account/${uid}/rolecontext/${contextName}`;
 
     return config.request('DELETE', resourcePath, queryParameters, null);
   };
@@ -194,7 +194,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/rolecontext/' + contextName + '/role';
+    var resourcePath = `identity/v2/manage/account/${uid}/rolecontext/${contextName}/role`;
 
     return config.request('DELETE', resourcePath, queryParameters, roleContextRemoveRoleModel);
   };
@@ -224,7 +224,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/rolecontext/' + contextName + '/additionalpermission';
+    var resourcePath = `identity/v2/manage/account/${uid}/rolecontext/${contextName}/additionalpermission`;
 
     return config.request('DELETE', resourcePath, queryParameters, roleContextAdditionalPermissionRemoveRoleModel);
   };
@@ -308,7 +308,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/role/' + role + '/permission';
+    var resourcePath = `identity/v2/manage/role/${role}/permission`;
 
     return config.request('PUT', resourcePath, queryParameters, permissionsModel);
   };
@@ -333,7 +333,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/role/' + role + '/permission';
+    var resourcePath = `identity/v2/manage/role/${role}/permission`;
 
     return config.request('DELETE', resourcePath, queryParameters, permissionsModel);
   };

--- a/loginradius-sdk/sdk/api/advanced/consentManagementApi.js
+++ b/loginradius-sdk/sdk/api/advanced/consentManagementApi.js
@@ -22,7 +22,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/consent/logs';
+    var resourcePath = `identity/v2/manage/account/${uid}/consent/logs`;
 
     return config.request('GET', resourcePath, queryParameters, null);
   };

--- a/loginradius-sdk/sdk/api/advanced/customObjectApi.js
+++ b/loginradius-sdk/sdk/api/advanced/customObjectApi.js
@@ -190,7 +190,7 @@ module.exports = function (config) {
     queryParameters.apiSecret = config.apiSecret;
     queryParameters.objectName = objectName;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/customobject';
+    var resourcePath = `identity/v2/manage/account/${uid}/customobject`;
 
     return config.request('POST', resourcePath, queryParameters, payload);
   };
@@ -229,7 +229,7 @@ module.exports = function (config) {
       queryParameters.updateType = updateType;
     }
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/customobject/' + objectRecordId;
+    var resourcePath = `identity/v2/manage/account/${uid}/customobject/${objectRecordId}`;
 
     return config.request('PUT', resourcePath, queryParameters, payload);
   };
@@ -255,7 +255,7 @@ module.exports = function (config) {
     queryParameters.apiSecret = config.apiSecret;
     queryParameters.objectName = objectName;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/customobject';
+    var resourcePath = `identity/v2/manage/account/${uid}/customobject`;
 
     return config.request('GET', resourcePath, queryParameters, null);
   };
@@ -286,7 +286,7 @@ module.exports = function (config) {
     queryParameters.apiSecret = config.apiSecret;
     queryParameters.objectName = objectName;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/customobject/' + objectRecordId;
+    var resourcePath = `identity/v2/manage/account/${uid}/customobject/${objectRecordId}`;
 
     return config.request('GET', resourcePath, queryParameters, null);
   };
@@ -317,7 +317,7 @@ module.exports = function (config) {
     queryParameters.apiSecret = config.apiSecret;
     queryParameters.objectName = objectName;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/customobject/' + objectRecordId;
+    var resourcePath = `identity/v2/manage/account/${uid}/customobject/${objectRecordId}`;
 
     return config.request('DELETE', resourcePath, queryParameters, null);
   };

--- a/loginradius-sdk/sdk/api/advanced/customObjectApi.js
+++ b/loginradius-sdk/sdk/api/advanced/customObjectApi.js
@@ -71,7 +71,7 @@ module.exports = function (config) {
       queryParameters.updateType = updateType;
     }
 
-    var resourcePath = 'identity/v2/auth/customobject/' + objectRecordId;
+    var resourcePath = `identity/v2/auth/customobject/${objectRecordId}`;
 
     return config.request('PUT', resourcePath, queryParameters, payload);
   };
@@ -128,7 +128,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.objectName = objectName;
 
-    var resourcePath = 'identity/v2/auth/customobject/' + objectRecordId;
+    var resourcePath = `identity/v2/auth/customobject/${objectRecordId}`;
 
     return config.request('GET', resourcePath, queryParameters, null);
   };
@@ -159,7 +159,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.objectName = objectName;
 
-    var resourcePath = 'identity/v2/auth/customobject/' + objectRecordId;
+    var resourcePath = `identity/v2/auth/customobject/${objectRecordId}`;
 
     return config.request('DELETE', resourcePath, queryParameters, null);
   };

--- a/loginradius-sdk/sdk/api/advanced/customRegistrationDataApi.js
+++ b/loginradius-sdk/sdk/api/advanced/customRegistrationDataApi.js
@@ -34,7 +34,7 @@ module.exports = function (config) {
       queryParameters.skip = skip;
     }
 
-    var resourcePath = 'identity/v2/auth/registrationdata/' + type;
+    var resourcePath = `identity/v2/auth/registrationdata/${type}`;
 
     return config.request('GET', resourcePath, queryParameters, null);
   };
@@ -96,7 +96,7 @@ module.exports = function (config) {
       queryParameters.skip = skip;
     }
 
-    var resourcePath = 'identity/v2/manage/registrationdata/' + type;
+    var resourcePath = `identity/v2/manage/registrationdata/${type}`;
 
     return config.request('GET', resourcePath, queryParameters, null);
   };
@@ -142,7 +142,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/registrationdata/' + recordId;
+    var resourcePath = `identity/v2/manage/registrationdata/${recordId}`;
 
     return config.request('PUT', resourcePath, queryParameters, registrationDataUpdateModel);
   };
@@ -163,7 +163,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/registrationdata/' + recordId;
+    var resourcePath = `identity/v2/manage/registrationdata/${recordId}`;
 
     return config.request('DELETE', resourcePath, queryParameters, null);
   };
@@ -184,7 +184,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/registrationdata/type/' + type;
+    var resourcePath = `identity/v2/manage/registrationdata/type/${type}`;
 
     return config.request('DELETE', resourcePath, queryParameters, null);
   };

--- a/loginradius-sdk/sdk/api/advanced/reAuthenticationApi.js
+++ b/loginradius-sdk/sdk/api/advanced/reAuthenticationApi.js
@@ -156,7 +156,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/reauth/2fa';
+    var resourcePath = `identity/v2/manage/account/${uid}/reauth/2fa`;
 
     return config.request('POST', resourcePath, queryParameters, eventBasedMultiFactorToken);
   };
@@ -181,7 +181,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/reauth/password';
+    var resourcePath = `identity/v2/manage/account/${uid}/reauth/password`;
 
     return config.request('POST', resourcePath, queryParameters, eventBasedMultiFactorToken);
   };
@@ -206,7 +206,7 @@ module.exports = function (config) {
     queryParameters.apiKey = config.apiKey;
     queryParameters.apiSecret = config.apiSecret;
 
-    var resourcePath = 'identity/v2/manage/account/' + uid + '/reauth/pin';
+    var resourcePath = `identity/v2/manage/account/${uid}/reauth/pin`;
 
     return config.request('POST', resourcePath, queryParameters, eventBasedMultiFactorToken);
   };

--- a/loginradius-sdk/sdk/util/helper.js
+++ b/loginradius-sdk/sdk/util/helper.js
@@ -73,7 +73,7 @@ var getSott = function (config, startDate, endDate) {
  * @return jsondata as json error object
  */
 var getValidationMessage = function (type) {
-  jsondata.Description = 'The API Request Paramter ' + type + ' is not Correct or WellFormated';
+  jsondata.Description = `The API Request Paramter ${type} is not Correct or WellFormated`;
   return jsondata;
 };
 
@@ -115,15 +115,15 @@ var generateSigningHeader = function (options, apiSecret) {
   expiryDate = new Date(expiryDate.getTime() + SIXTY * SIXTYTHOUSAND);
   var month = expiryDate.getMonth() + 1;
 
-  expiryDate = expiryDate.getFullYear() + '-' + (month < TEN ? '0' + month : month) + '-' + (expiryDate.getDate() < TEN ? '0' + expiryDate.getDate() : expiryDate.getDate()) + ' ' + (expiryDate.getHours() < TEN ? '0' + expiryDate.getHours() : expiryDate.getHours()) + ':' + (expiryDate.getMinutes() < TEN ? '0' + expiryDate.getMinutes() : expiryDate.getMinutes()) + ':' + (expiryDate.getSeconds() < TEN ? '0' + expiryDate.getSeconds() : expiryDate.getSeconds());
+  expiryDate = `${expiryDate.getFullYear()}-${(month < TEN ? '0' + month : month)}-${(expiryDate.getDate() < TEN ? '0' + expiryDate.getDate() : expiryDate.getDate())} ${(expiryDate.getHours() < TEN ? '0' + expiryDate.getHours() : expiryDate.getHours())}:${(expiryDate.getMinutes() < TEN ? '0' + expiryDate.getMinutes() : expiryDate.getMinutes())}:${(expiryDate.getSeconds() < TEN ? '0' + expiryDate.getSeconds() : expiryDate.getSeconds())}`;
 
   var encodeUrl = encodeURIComponent(decodeURIComponent(options.uri)).toLowerCase();
 
   var urlString;
   if (options.body) {
-    urlString = expiryDate + ':' + encodeUrl + ':' + options.body;
+    urlString = `${expiryDate}:${encodeUrl}:${options.body}`;
   } else {
-    urlString = expiryDate + ':' + encodeUrl;
+    urlString = `${expiryDate}:${encodeUrl}`;
   }
   var hash = crypto.createHmac('sha256', apiSecret)
     .update(urlString)
@@ -131,7 +131,7 @@ var generateSigningHeader = function (options, apiSecret) {
 
   return {
     'X-Request-Expires': expiryDate,
-    'digest': 'SHA-256=' + hash
+    'digest': `SHA-256=${hash}`
   };
 };
 

--- a/loginradius-sdk/sdk/util/helper.js
+++ b/loginradius-sdk/sdk/util/helper.js
@@ -108,14 +108,16 @@ var getQueryString = function (string) {
  * @return header object
  */
 var generateSigningHeader = function (options, apiSecret) {
+  var padTen = function (number) {
+    return number.toString().padStart(2, '0')
+  }
   var SIXTY = 60;
   var SIXTYTHOUSAND = 60000;
-  var TEN = 10;
   var expiryDate = new Date();
   expiryDate = new Date(expiryDate.getTime() + SIXTY * SIXTYTHOUSAND);
   var month = expiryDate.getMonth() + 1;
 
-  expiryDate = `${expiryDate.getFullYear()}-${(month < TEN ? '0' + month : month)}-${(expiryDate.getDate() < TEN ? '0' + expiryDate.getDate() : expiryDate.getDate())} ${(expiryDate.getHours() < TEN ? '0' + expiryDate.getHours() : expiryDate.getHours())}:${(expiryDate.getMinutes() < TEN ? '0' + expiryDate.getMinutes() : expiryDate.getMinutes())}:${(expiryDate.getSeconds() < TEN ? '0' + expiryDate.getSeconds() : expiryDate.getSeconds())}`;
+  expiryDate = `${expiryDate.getFullYear()}-${padTen(month)}-${padTen(expiryDate.getDate())} ${padTen(expiryDate.getHours())}:${padTen(expiryDate.getMinutes())}:${padTen(expiryDate.getSeconds())}`;
 
   var encodeUrl = encodeURIComponent(decodeURIComponent(options.uri)).toLowerCase();
 

--- a/loginradius-sdk/sdk/util/lr.js
+++ b/loginradius-sdk/sdk/util/lr.js
@@ -35,14 +35,14 @@ module.exports = function (config = {}) {
     if (queryParameters.access_token) {
       Object.assign(
         headers,
-        { 'authorization': 'Bearer ' + queryParameters.access_token }
+        { 'authorization': `Bearer ${queryParameters.access_token}` }
       );
       delete queryParameters.access_token;
     }
     var options = {
       method: type,
       hostname: ((resourcePath === 'ciam/appinfo') ? 'config.lrcontent.com' : config.apiDomain),
-      path: '/' + resourcePath + ((queryString) ? '?' + queryString : ''),
+      path: `/${resourcePath}${((queryString) ? '?' + queryString : '')}`,
       headers: headers
     };
 
@@ -55,7 +55,7 @@ module.exports = function (config = {}) {
     }
 
     if (config.proxy && config.proxy.host && config.proxy.port) {
-      options.proxy = (config.proxy.protocol ? config.proxy.protocol : 'http') + '://' + config.proxy.user + ':' + config.proxy.password + '@' + config.proxy.host + ':' + config.proxy.port;
+      options.proxy = `${(config.proxy.protocol ? config.proxy.protocol : 'http')}://${config.proxy.user}:${config.proxy.password}@${config.proxy.host}:${config.proxy.port}`;
     }
 
     var customHeader = {
@@ -77,7 +77,7 @@ module.exports = function (config = {}) {
     if (isApiSecret) {
       if (config.apiRequestSigning) {
         if (!options.path.match('apiKey')) {
-          options.path += '&apiKey=' + encodeURIComponent(config.apiKey);
+          options.path += `&apiKey=${encodeURIComponent(config.apiKey)}`;
         }
         var signingHeader = helper.generateSigningHeader(options, config.apiSecret);
 

--- a/loginradius-sdk/sdk/util/lr.js
+++ b/loginradius-sdk/sdk/util/lr.js
@@ -69,7 +69,7 @@ module.exports = function (config = {}) {
         fieldsList = config.fieldsParam +
           encodeURIComponent(config.fieldsValue);
       } else {
-        fieldsList = '?fields=' + encodeURIComponent(config.fieldsValue);
+        fieldsList = `?fields=${encodeURIComponent(config.fieldsValue)}`;
       }
       options.path += fieldsList;
     }

--- a/loginradius-sdk/sdk/util/sott.js
+++ b/loginradius-sdk/sdk/util/sott.js
@@ -14,7 +14,7 @@ module.exports = function (secret, key, startDate, endDate) {
 
         tempToken += date.getUTCFullYear() + '/' + nextMonth + '/' + date.getUTCDate() + ' ' + date.getUTCHours() + ':' + (date.getUTCMinutes() < 10 ? '0' + date.getUTCMinutes() : date.getUTCMinutes()) + ':' + (date.getUTCSeconds() < 10 ? '0' + date.getUTCSeconds() : date.getUTCSeconds());
       } else {
-        tempToken = startDate + '#' + key + '#' + endDate;
+        tempToken = `${startDate}#${key}#${endDate}`;
       }
       encrypt(tempToken, resolve, reject);
     }

--- a/loginradius-sdk/sdk/util/sott.js
+++ b/loginradius-sdk/sdk/util/sott.js
@@ -1,6 +1,9 @@
 'use strict';
 
 module.exports = function (secret, key, startDate, endDate) {
+  var padTen = function (number) {
+    return number.toString().padStart(2, '0')
+  }
   var crypto = require('crypto');
 
   return new Promise(
@@ -9,10 +12,10 @@ module.exports = function (secret, key, startDate, endDate) {
       if (!startDate) {
         var date = new Date();
         var nextMonth = date.getUTCMonth() + 1;
-        tempToken = date.getUTCFullYear() + '/' + nextMonth + '/' + date.getUTCDate() + ' ' + date.getUTCHours() + ':' + (date.getUTCMinutes() < 10 ? '0' + date.getUTCMinutes() : date.getUTCMinutes()) + ':' + (date.getUTCSeconds() < 10 ? '0' + date.getUTCSeconds() : date.getUTCSeconds()) + '#' + key + '#';
+        tempToken = `${date.getUTCFullYear()}/${nextMonth}/${date.getUTCDate()} ${date.getUTCHours()}:${padTen(date.getUTCMinutes())}:${padTen(date.getUTCSeconds())}#${key}#`;
         date.setUTCMinutes(date.getUTCMinutes() + 10);
 
-        tempToken += date.getUTCFullYear() + '/' + nextMonth + '/' + date.getUTCDate() + ' ' + date.getUTCHours() + ':' + (date.getUTCMinutes() < 10 ? '0' + date.getUTCMinutes() : date.getUTCMinutes()) + ':' + (date.getUTCSeconds() < 10 ? '0' + date.getUTCSeconds() : date.getUTCSeconds());
+        tempToken += `${date.getUTCFullYear()}/${nextMonth}/${date.getUTCDate()} ${date.getUTCHours()}:${padTen(date.getUTCMinutes())}:${padTen(date.getUTCSeconds())}`;
       } else {
         tempToken = `${startDate}#${key}#${endDate}`;
       }
@@ -20,7 +23,7 @@ module.exports = function (secret, key, startDate, endDate) {
     }
   );
 
-  function encrypt (plainText, resolve, reject) {
+  function encrypt(plainText, resolve, reject) {
     var initVector = 'tu89geji340t89u2';
     var keySize = 256;
     var iterations = 10000;
@@ -35,7 +38,7 @@ module.exports = function (secret, key, startDate, endDate) {
 
       var hash = crypto.createHash('md5');
       hash.update(cryptedText, 'ascii');
-      resolve(cryptedText + '*' + (hash.digest()).toString('hex'));
+      resolve(`${cryptedText}*${(hash.digest()).toString('hex')}`);
     });
   }
 };


### PR DESCRIPTION
This PR provides:
* A cleaner solution to the padding of zero in one-digit numbers (using built-in `padStart(2, '0')`)
* Usage of Template Literals instead of connecting multiple strings